### PR TITLE
Support segment-literal notation '[' for referencing properties that are not valid identifiers.

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -82,9 +82,11 @@ boolean ::= <false>|<true>
 false ::= 'f' 'a' 'l' 's' 'e' => False
 true ::= 't' 'r' 'u' 'e' => True
 notquote ::= <escapedquote> | (~('"') <anything>)
+notclosebracket ::= (~(']') <anything>)
 escapedquote ::= '\\' '"' => '\\"'
 symbol ::=  ~<alt_inner> '['? (<letterOrDigit>|'-'|'@')+:symbol ']'? => u''.join(symbol)
-pathseg ::= <symbol>
+pathseg ::= '[' <notclosebracket>+:symbol ']' => u''.join(symbol)
+    | <symbol>
     | '/' => u''
     | ('.' '.' '/') => u'__parent'
     | '.' => u''

--- a/pybars/tests/test__compiler.py
+++ b/pybars/tests/test__compiler.py
@@ -88,3 +88,8 @@ class TestCompiler(TestCase):
             'title': u"All about <p> Tags",
             'body': u"<p>This is a post about &lt;p&gt; tags</p>",
             }))
+
+    def test_segment_literal_notation(self):
+        self.assertEqual(u"""hello""",
+            render(u"""{{foo.[bar baz]}}""",
+                {'foo': {'bar baz': 'hello' }}))


### PR DESCRIPTION
As described in http://handlebarsjs.com/expressions.html
