### PR TITLE
[security] Fixing code generation for invalid templates.

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -74,15 +74,17 @@ block_inner ::= <spaces> <symbol>:s <arguments>:args <spaces> <finish>
 alt_inner ::= <spaces> ('^' | 'e' 'l' 's' 'e') <spaces> <finish>
 partial ::= <start> '>' <block_inner>:i => ('partial',) + i
 path ::= ~('/') <pathseg>+:segments => ('path', segments)
-kwliteral ::= <symbol>:s '=' (<literal>|<path>):v => ('kwparam', s, v)
+kwliteral ::= <safesymbol>:s '=' (<literal>|<path>):v => ('kwparam', s, v)
 literal ::= (<string>|<integer>|<boolean>):thing => ('literalparam', thing)
 string ::= '"' <notquote>*:ls '"' => u'"' + u''.join(ls) + u'"'
 integer ::= <digit>+:ds => int(''.join(ds))
 boolean ::= <false>|<true>
 false ::= 'f' 'a' 'l' 's' 'e' => False
 true ::= 't' 'r' 'u' 'e' => True
-notquote ::= <escapedquote> | (~('"') <anything>)
+notquote ::= <escapedquote> | (~('\\' | '"' | '\n' | '\r') <anything>)
 escapedquote ::= '\\' '"' => '\\"'
+    | '\\' '\\' => '\\\\'
+safesymbol ::=  ~<alt_inner> '['? (<letter>|'_'):start (<letterOrDigit>|'_')+:symbol ']'? => start + u''.join(symbol)
 symbol ::=  ~<alt_inner> '['? (<letterOrDigit>|'-'|'@')+:symbol ']'? => u''.join(symbol)
 pathseg ::= <symbol>
     | '/' => u''

--- a/pybars/tests/test_acceptance.py
+++ b/pybars/tests/test_acceptance.py
@@ -768,3 +768,11 @@ class TestAcceptance(TestCase):
             }
         expected = "<strong>This is a slightly more complicated blah.</strong>.\n\nCheck this out:\n\n<ul>\n\n<li class=one>@fat</li>\n\n<li class=two>@dhg</li>\n\n<li class=three>@sayrer</li>\n</ul>.\n\n"
         self.assertEqual(expected, render(source, context))
+
+    def test_invalid_template_1(self):
+        source = u'{{ x "\\x" }}'
+        self.assertEqual('', render(source, {}))
+
+    def test_invalid_template_2(self):
+        source = u'{{ foo 0x="bar" }}'
+        self.assertEqual('', render(source, {}))


### PR DESCRIPTION
This pull request fixes code generation for invalid template strings, which may result in execution of arbitrary Python code when rendering certain templates.