### PR TITLE
Fix the way _each handles @key for dict

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -225,12 +225,13 @@ def resolve(context, *segments):
 def _each(this, options, context):
     result = strlist()
     i = 0
-    for local_context in context:
+    for local_context in iter(context):
         kwargs = {}
         if isinstance(context, list):
             kwargs['index'] = i
         if isinstance(context, dict):
             kwargs['key'] = local_context
+            local_context = context.get(local_context)
         scope = Scope(local_context, this, **kwargs)
         result.grow(options['fn'](scope))
         i += 1


### PR DESCRIPTION
Prior to this patch the following template would fail when `foo` was an instance of `dict`:

```
{{#each foo}}
    {{@key}}: {{this}}
{{/each}}
```

In the case where `foo = {'bar': 'baz'}` one would expect the output to be `bar: baz`, but instead the output is `bar: bar`.

The following code addresses this bug by using `iter` to get the iterable items of the collection, whether it be a `list` or a `dict`. If it's a `dict`, then `local_context` is set to be the value for the appropriate key before it's passed to the `Scope` constructor.
