### PR TITLE
Make partial names support additional special characters and quote escaping

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -71,8 +71,10 @@ expression ::= <start> '{' <expression_inner>:e '}' => ('expand', ) + e
 escapedexpression ::= <start> <expression_inner>:e => ('escapedexpand', ) + e
 block_inner ::= <spaces> <symbol>:s <arguments>:args <spaces> <finish>
     => (u''.join(s), args)
+partial_inner ::= <spaces> <partialname>:s <arguments>:args <spaces> <finish>
+    => (u''.join(s), args)
 alt_inner ::= <spaces> ('^' | 'e' 'l' 's' 'e') <spaces> <finish>
-partial ::= <start> '>' <block_inner>:i => ('partial',) + i
+partial ::= <start> '>' <partial_inner>:i => ('partial',) + i
 path ::= ~('/') <pathseg>+:segments => ('path', segments)
 kwliteral ::= <symbol>:s '=' (<literal>|<path>):v => ('kwparam', s, v)
 literal ::= (<string>|<integer>|<boolean>):thing => ('literalparam', thing)
@@ -84,6 +86,7 @@ true ::= 't' 'r' 'u' 'e' => True
 notquote ::= <escapedquote> | (~('"') <anything>)
 escapedquote ::= '\\' '"' => '\\"'
 symbol ::=  ~<alt_inner> '['? (<letterOrDigit>|'-'|'@')+:symbol ']'? => u''.join(symbol)
+partialname ::= ~<alt_inner> ('['|'"')? (~(<space>|<finish>|']'|'"' ) <anything>)+:symbol (']'|'"')? => u''.join(symbol)
 pathseg ::= ('@' '.' '.' '/') => u'@@_parent'
     | <symbol>
     | '/' => u''

--- a/pybars/tests/test_acceptance.py
+++ b/pybars/tests/test_acceptance.py
@@ -509,6 +509,13 @@ class TestAcceptance(TestCase):
         self.assertEqual("Dudes: Jeepers",
             render(source, context, partials=dict(dude=dude_src)))
 
+    def test_partials_with_string(self):
+        source = u'Dudes: {{> "+404/asdf?.bar"}}';
+        dude_src = u"{{name}}"
+        context = {'name': "Jeepers", 'another_dude': "Creepers"}
+        self.assertEqual("Dudes: Jeepers",
+            render(source, context, partials={'+404/asdf?.bar':dude_src}))
+
     def test_simple_literals_work(self):
         source = u'Message: {{hello "world" 12 true false}}'
         def hello(this, param, times, bool1, bool2):


### PR DESCRIPTION
...scaped aspects.

Copying test from https://github.com/wycats/handlebars.js/blob/2a4819d75cba7513946af5cf28ee22881561814f/spec/partials.js#L144
This is also motivated by wanting to have file-named partials with / and .s e.g. foo/bar.html