### PR TITLE
Pybars grammar improvements

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -74,15 +74,20 @@ block_inner ::= <spaces> <symbol>:s <arguments>:args <spaces> <finish>
 alt_inner ::= <spaces> ('^' | 'e' 'l' 's' 'e') <spaces> <finish>
 partial ::= <start> '>' <block_inner>:i => ('partial',) + i
 path ::= ~('/') <pathseg>+:segments => ('path', segments)
-kwliteral ::= <symbol>:s '=' (<literal>|<path>):v => ('kwparam', s, v)
+kwliteral ::= <safesymbol>:s '=' (<literal>|<path>):v => ('kwparam', s, v)
 literal ::= (<string>|<integer>|<boolean>):thing => ('literalparam', thing)
 string ::= '"' <notquote>*:ls '"' => u'"' + u''.join(ls) + u'"'
 integer ::= '-'?:sign <digit>+:ds => int((sign if sign else '') + ''.join(ds))
 boolean ::= <false>|<true>
 false ::= 'f' 'a' 'l' 's' 'e' => False
 true ::= 't' 'r' 'u' 'e' => True
-notquote ::= <escapedquote> | (~('"') <anything>)
+notquote ::= <escapedquote>
+    | '\n' => '\\n'
+    | '\r' => '\\r'
+    | '\\' => '\\\\'
+    | (~('"') <anything>)
 escapedquote ::= '\\' '"' => '\\"'
+safesymbol ::=  ~<alt_inner> '['? (<letter>|'_'):start (<letterOrDigit>|'_')+:symbol ']'? => start + u''.join(symbol)
 symbol ::=  ~<alt_inner> '['? (<letterOrDigit>|'-'|'@')+:symbol ']'? => u''.join(symbol)
 pathseg ::= ('@' '.' '.' '/') => u'@@_parent'
     | <symbol>


### PR DESCRIPTION
Fixes several grammar issues:
- Allows newlines in string literals in templates
- Allows template variable names that would be invalid Python identifiers
- Addresses security considerations mentioned by @thomasst in issue #3