### PR TITLE
Dictionary keys take precedence over attributes

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -212,10 +212,10 @@ def escape(something, _escape_re=_escape_re, substitute=substitute):
 
 
 def pick(context, name, default=None):
-    if isinstance(name, str) and hasattr(context, name):
-        return getattr(context, name)
     if hasattr(context, 'get'):
         return context.get(name)
+    if isinstance(name, str) and hasattr(context, name):
+        return getattr(context, name)
     try:
         return context[name]
     except (KeyError, TypeError):

--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -212,13 +212,13 @@ def escape(something, _escape_re=_escape_re, substitute=substitute):
 
 
 def pick(context, name, default=None):
-    if hasattr(context, 'get'):
-        return context.get(name)
-    if isinstance(name, str) and hasattr(context, name):
-        return getattr(context, name)
     try:
         return context[name]
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, AttributeError):
+        if isinstance(name, str) and hasattr(context, name):
+            return getattr(context, name)
+        if hasattr(context, 'get'):
+            return context.get(name)
         return default
 
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -2126,5 +2126,11 @@ class TestAcceptance(TestCase):
         }
         result = 'hello'
 
+        context2 = {
+            "hello": MyDict()
+        }
+        result2 = "goodbye"
+
         self.assertRender(template, context, result)
+        self.assertRender(template, context2, result2)
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -2115,3 +2115,16 @@ class TestAcceptance(TestCase):
         finally:
             if os.path.exists('test_precompile.py'):
                 os.unlink('test_precompile.py')
+
+    def test_attribute_precedence(self):
+        class MyDict(dict):
+            world = "goodbye"
+
+        template = u"{{hello.world}}"
+        context = {
+            "hello": MyDict({"world": "hello"})
+        }
+        result = 'hello'
+
+        self.assertRender(template, context, result)
+


### PR DESCRIPTION
Fixes #16, but might break legacy code in some specific edge cases (namely when passing contexts with both a `get()` function and custom attributes)