### PR TITLE
Fix for #17 and #18

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -370,6 +370,26 @@ class TestAcceptance(TestCase):
 
         self.assertRender(template, context, result)
 
+    def test_inverted_alternate_sections(self):
+        # We use this form to not introduce extra whitespace
+        template = (
+            u"{{#goodbyes}}{{this}}{{else}}Right On!{{/goodbyes}}\n"
+            u"{{^goodbyes}}Right On!{{else}}{{this}}{{/goodbyes}}"
+        )
+        result = "Right On!\nRight On!"
+
+        context = {}
+
+        self.assertRender(template, context, result)
+
+        context = {'goodbyes': False}
+
+        self.assertRender(template, context, result)
+
+        context = {'goodbyes': []}
+
+        self.assertRender(template, context, result)
+
     def test_array_iteration(self):
         template = u"{{#goodbyes}}{{text}}! {{/goodbyes}}cruel {{world}}!"
 


### PR DESCRIPTION
Previously add many errors around the ^ operation.  I added a bit to the grammar to be able to support "else" statements, then modified the add_invertedblock method (to be similar to add_block).  From testing, it seems to work as expected.

I also added a few unit tests, although there are probably a few tests to be added still.