### PR TITLE
Escape arg segments to prevent arbitrary code execution

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -225,10 +225,13 @@ def escape(something, _escape_re=_escape_re, substitute=substitute):
 
 
 def pick(context, name, default=None):
-    if isinstance(context, dict):
-        return context.get(name, None)
-
-    return None
+    try:
+        return context.get(name)
+    except (KeyError, TypeError, AttributeError):
+        value = getattr(context, name)
+    if not callable(value):
+        return value
+    return default
 
 
 sentinel = object()

--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -226,9 +226,9 @@ def escape(something, _escape_re=_escape_re, substitute=substitute):
 
 def pick(context, name, default=None):
     try:
-        return context.get(name)
+        return context[name]
     except (KeyError, TypeError, AttributeError):
-        value = getattr(context, name)
+        value = getattr(context, name, default)
     if not callable(value):
         return value
     return default

--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -225,21 +225,10 @@ def escape(something, _escape_re=_escape_re, substitute=substitute):
 
 
 def pick(context, name, default=None):
-    try:
-        return context[name]
-    except (KeyError, TypeError, AttributeError):
-        if isinstance(name, basestring):
-            try:
-                exists = hasattr(context, name)
-            except UnicodeEncodeError:
-                # Python 2 raises UnicodeEncodeError on non-ASCII strings
-                pass
-            else:
-                if exists:
-                    return getattr(context, name)
-        if hasattr(context, 'get'):
-            return context.get(name)
-        return default
+    if isinstance(context, dict):
+        return context.get(name, None)
+
+    return None
 
 
 sentinel = object()

--- a/tests/test__compiler.py
+++ b/tests/test__compiler.py
@@ -25,7 +25,7 @@ import sys
 
 from unittest import TestCase
 
-from pybars import Compiler
+from pybars import Compiler, PybarsError
 
 
 def render(source, context, helpers=None, partials=None, knownHelpers=None,
@@ -116,6 +116,19 @@ class TestCompiler(TestCase):
         result = u"""hello"""
 
         self.assertEqual(result, render(template, context))
+
+    def test_arbitrary_code_execution(self):
+        for template in [
+            u"{{#if ['));exit(1);((']}}{{/if}}",
+            u"{{['+exit(1)+']}}",
+            u"{{[');exit(1)#]}}",
+        ]:
+            render(template, {})
+
+        try:
+            render(u"{{> ([log\", \"\", \"\");exit(1)#])}}", {})
+        except PybarsError:
+            pass
 
     def test_compile_with_path(self):
         template = u"Hi {{name}}!"

--- a/tests/test__compiler.py
+++ b/tests/test__compiler.py
@@ -122,8 +122,9 @@ class TestCompiler(TestCase):
             u"{{#if ['));exit(1);((']}}{{/if}}",
             u"{{['+exit(1)+']}}",
             u"{{[');exit(1)#]}}",
+            u"{{foo.join}}"
         ]:
-            render(template, {})
+            render(template, {"foo": "bar"})
 
         try:
             render(u"{{> ([log\", \"\", \"\");exit(1)#])}}", {})

--- a/tests/test__compiler.py
+++ b/tests/test__compiler.py
@@ -122,9 +122,10 @@ class TestCompiler(TestCase):
             u"{{#if ['));exit(1);((']}}{{/if}}",
             u"{{['+exit(1)+']}}",
             u"{{[');exit(1)#]}}",
-            u"{{foo.join}}"
+            u"{{foo.join}}",
+            u"{{__class__.__base__.__setattr__ 'get' bar.func_globals.__builtins__.eval}} {{[__import__('subprocess').call('id')]}}"
         ]:
-            render(template, {"foo": "bar"})
+            render(template, {"foo": "bar", "bar": lambda _: _})
 
         try:
             render(u"{{> ([log\", \"\", \"\");exit(1)#])}}", {})


### PR DESCRIPTION
See the test. Arguments to helpers were being passed in unescaped making arbitrary code execution possible. This PR escapes those arguments.