### PR TITLE
Fixed a SyntaxError issue in _compiler.py with Python < 2.7.8

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -898,7 +898,7 @@ class Compiler:
                 'partials': partials,
                 'root': root
             }
-            exec(code + '\nresult = render(context, helpers=helpers, partials=partials, root=root)', ns)
+            exec(code + '\nresult = render(context, helpers=helpers, partials=partials, root=root)') in ns
             return ns['result']
         return _render
 


### PR DESCRIPTION
Hi,

`pybars3-0.9.6` currently fails on CentOS 7.6 (its default Python version is 2.7.5) with the following kind of error:

```
  File "pybars/__init__.py", line 30, in <module>                               
    from pybars._compiler import (                                                                                        
  File "pybars/_compiler.py", line 902                                          
    exec(code + '\nresult = render(context, helpers=helpers, partials=partials, root=root)', ns)                          
SyntaxError: unqualified exec is not allowed in function '_render' it is a nested function   
```

It looks like this was an internal bug in early releases of Python 2.7 (https://bugs.python.org/issue21591) which was fixed around Python 2.7.8. Unfortunately, CentOS 7 still ships Python 2.7.5 by default.

Other projects worked around this by using an alternative syntax that doesn't trigger this error with early Python 2.7 versions: https://github.com/plone/plone.protect/pull/76/files#diff-41a4c6407f64bbc479d3af2fbfae7617, https://github.com/victorlei/smop/issues/129#issuecomment-444799736.

The following PR tries to replicate this workaround, to preserve Python 2.7 compatibility.