### PR TITLE
Add "list.length" support

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -312,6 +312,8 @@ def resolve(context, *segments):
         if segment in (None, ""):
             continue
         if type(context) in (list, tuple):
+            if segment == 'length':
+                return len(context)
             offset = int(segment)
             context = context[offset]
         elif isinstance(context, Scope):

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -643,6 +643,16 @@ class TestAcceptance(TestCase):
 
         self.assertRender(template, context, result)
 
+    def test_array_length(self):
+        template = u"{{array.length}}"
+
+        context = {
+            'array': ['1', '2', '3']
+        }
+        result = u"3"
+
+        self.assertRender(template, context, result)
+
     def test_unicode_array_iteration(self):
         template = u"{{#سلامات}}{{النص}}! {{/سلامات}}cruel {{world}}!"
 


### PR DESCRIPTION
Rendering `{{list.length}}` now correctly return the list length instead of crashing.