### PR TITLE
Support else for unless, and add a test for it

### DIFF
--- a/pybars/_compiler.py
+++ b/pybars/_compiler.py
@@ -419,6 +419,8 @@ def _log(this, context):
 def _unless(this, options, context):
     if not context:
         return options['fn'](this)
+    else:
+        return options['inverse'](this)
 
 
 def _lookup(this, context, key):

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1944,6 +1944,17 @@ class TestAcceptance(TestCase):
 
         self.assertRender(template, context, result)
 
+    def test_unless_else(self):
+        template = u"{{#unless goodbye}}Hello{{else}}GOODBYE{{/unless}} cruel world"
+
+        context = {
+            'goodbye': True
+        }
+
+        result = u"GOODBYE cruel world"
+
+        self.assertRender(template, context, result)
+
     def test_resolve_with_attrs(self):
 
         class TestAttr():


### PR DESCRIPTION
This adds support for `{{else}}` to `{{#unless}}`, and adds a test for it. There is an existing PR for this, but the person who opened it never added tests, and it's been 3 years, so I don't think it'll ever get merged.