### PR TITLE
Add support for partial blocks

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -2747,3 +2747,39 @@ class TestAcceptance(TestCase):
         text = u"Hola {{name}}!"
         context = {'name': u"Samira"}
         self.assertRender(text, context, u"Hola Samira!")
+
+    def test_partial_block_fallback(self):
+        template = u"Hello {{#> non_existent_partial}}World{{/non_existent_partial}}!"
+        context = {}
+        result = u"Hello World!"
+        self.assertRender(template, context, result)
+
+    def test_basic_partial_block(self):
+        partials = {
+            'name_partial': u"{{person.name}} and {{> @partial-block}}"
+        }
+
+        template = u"Hello {{#> name_partial person=person}}world{{/name_partial}}"
+        context = {
+            'person': {
+                'name': u"Samira"
+            }
+        }
+        result = u"Hello Samira and world"
+
+        self.assertRender(template, context, result, None, partials)
+
+    def test_partial_block_scoping(self):
+        partials = {
+            'name_partial': u"{{person.name}} and {{> @partial-block}}"
+        }
+
+        template = u"Hello {{#> name_partial person=person}}world{{/name_partial}}{{> @partial-block}}"
+        context = {
+            'person': {
+                'name': u"Samira"
+            }
+        }
+        result = u"Hello Samira and world"
+
+        self.assertRender(template, context, result, None, partials, "The partial @partial-block could not be found")


### PR DESCRIPTION
Hi, I'm interested in adding partial block support to pybars3 for use in one of my projects! This is my first time contributing to pybars so I'm not sure what the current status of external contributions is, but if you're willing to accept contributions I'm happy to work within your guidelines & best practices!

This PR adds in support for the [partial block feature of handlebar](https://handlebarsjs.com/guide/partials.html#partial-blocks). It adds the bear minimum functionality, namely fallbacks for missing templates and the use of the special `{{> @partial-block}}` partial for embedding content from caller to callee.

Let me know if this is something you're willing to include in the library, and what additional changes are needed to get there.

Thanks!

(addresses #72)